### PR TITLE
Support FreeBSD

### DIFF
--- a/sysctl.go
+++ b/sysctl.go
@@ -1,36 +1,72 @@
 package sysctl
 
 import (
-        "errors"
-        "io/ioutil"
-        "os"
-        "runtime"
-        "strings"
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"runtime"
+	"strings"
 )
 
 const (
-        sysctlDir = "/proc/sys/"
+	sysctlDir = "/proc/sys/"
 )
 
 var invalidKeyError = errors.New("could not find the given key")
 
+func linuxGet(name string) (string, error) {
+	path := sysctlDir + strings.Replace(name, ".", "/", -1)
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", invalidKeyError
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func freebsdGet(name string) (string, error) {
+	var stdout bytes.Buffer
+
+	cmd := exec.Command("sysctl", "-n", name)
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimRight(stdout.String(), "\n"), nil
+}
+
 func Get(name string) (string, error) {
-        if runtime.GOOS != "linux" {
-                os.Exit(1)
-        }
-        path := sysctlDir + strings.Replace(name, ".", "/", -1)
-        data, err := ioutil.ReadFile(path)
-        if err != nil {
-                return "",invalidKeyError
-        }
-        return strings.TrimSpace(string(data)),nil
+	switch runtime.GOOS {
+	case "linux":
+		return linuxGet(name)
+	case "freebsd":
+		return freebsdGet(name)
+	default:
+		return "", fmt.Errorf("sysctl: This runtime is not supported: %v", runtime.GOOS)
+	}
+}
+
+func linuxSet(name string, value string) error {
+	path := sysctlDir + strings.Replace(name, ".", "/", -1)
+	err := ioutil.WriteFile(path, []byte(value), 0644)
+	return err
+}
+
+func freebsdSet(name string, value string) error {
+	return exec.Command("sysctl", fmt.Sprintf("%s=%s", name, value)).Run()
 }
 
 func Set(name string, value string) error {
-        if runtime.GOOS != "linux" {
-                os.Exit(1)
-        }
-        path := sysctlDir + strings.Replace(name, ".", "/", -1)
-        err := ioutil.WriteFile(path, []byte(value), 0644)
-        return err
+	switch runtime.GOOS {
+	case "linux":
+		return linuxSet(name, value)
+	case "freebsd":
+		return freebsdSet(name, value)
+	default:
+		return fmt.Errorf("sysctl: This runtime is not supported: %v", runtime.GOOS)
+	}
 }

--- a/sysctl_test.go
+++ b/sysctl_test.go
@@ -1,31 +1,69 @@
 package sysctl
 
 import (
-        "testing"
+	"runtime"
+	"testing"
 )
 
 func TestGet(t *testing.T) {
-        got, err := Get("net.ipv4.tcp_sack")
-        ex := "1"
-        if err != nil {
-                t.Fatalf("Could not read key")
-        }
-        if got != ex {
-                t.Errorf("Expected: %s, got %s", ex, got)
-        }
+	var got string
+	var err error
+	switch runtime.GOOS {
+	case "freebsd":
+		got, err = Get("net.inet.tcp.sack.enable")
+	default:
+		got, err = Get("net.ipv4.tcp_sack")
+	}
+	ex := "1"
+	if err != nil {
+		t.Fatalf("Could not read key")
+	}
+	if got != ex {
+		t.Errorf("Expected: %s, got %s", ex, got)
+	}
+}
+
+func TestGetFailPattern(t *testing.T) {
+	param := "invalid_kernel_param"
+	got, err := Get(param)
+
+	if got != "" {
+		t.Fatalf("Expected: \"\", got %s", got)
+	}
+	if err == nil {
+		t.Fatal("Expected: returns some error but got nil")
+	}
 }
 
 func TestSet(t *testing.T) {
-        ex := "0"
-        err := Set("net.ipv4.ip_forward", ex)
-        if err != nil {
-                t.Fatalf("err")
-        }
-        got, err := Get("net.ipv4.ip_forward")
-        if err != nil {
-                t.Fatalf("Could not read key")
-        }
-        if got != ex {
-                t.Errorf("Expected: %s, got %s", ex, got)
-        }
+	var param, ex string
+	switch runtime.GOOS {
+	case "freebsd":
+		param = "compat.linux.debug"
+		ex = "2"
+	default:
+		param = "net.ipv4.ip_forward"
+		ex = "0"
+	}
+	err := Set(param, ex)
+	if err != nil {
+		t.Fatalf("Failed to call Set(%s, %s)", param, ex)
+	}
+	got, err := Get(param)
+	if err != nil {
+		t.Fatalf("Could not read key from %s", param)
+	}
+	if got != ex {
+		t.Errorf("Expected: %s, got %s from %s", ex, got, param)
+	}
+}
+
+func TestSetFailPattern(t *testing.T) {
+	param := "invalid_kernel_param"
+	ex := "0"
+	err := Set(param, ex)
+
+	if err == nil {
+		t.Fatalf("Expected: Set(%s, %s) returns error, returned nil", param, ex)
+	}
 }


### PR DESCRIPTION
Use sysctl(8) command to get/set kernel state in FreeBSD.

In get kernel state, "sysctl -n" means "Do not show variable names". For
example, `sysctl kern.ostype` shows "kern.ostype: FreeBSD" but
`sysctl -n kern.ostype` shows just "FreeBSD".

Update error messages in existing test. And add new test method for fail
pattern.